### PR TITLE
Possible mis-beavior for wrong return in auto_apply_edit_changes method of qtitem

### DIFF
--- a/libqtopensesame/items/qtitem.py
+++ b/libqtopensesame/items/qtitem.py
@@ -740,6 +740,8 @@ class qtitem(QtCore.QObject):
 			if type(var) == str:
 				self.set(var, editor.edit.toPlainText())
 				editor.setModified(False)
+
+		return True
 				
 	def auto_add_widget(self, widget, var=None):
 	


### PR DESCRIPTION
The method should return True or False.
Each plugin checks if the method returned a True value with:
<< if not auto_apply_edit_changes: >>
if no return statement is been specified the method return None and
thus the if statement always computes to False.
