### PR TITLE
Added set_pos and get_pressed to psycho mouse

### DIFF
--- a/openexp/_mouse/psycho.py
+++ b/openexp/_mouse/psycho.py
@@ -21,6 +21,7 @@ import openexp.mouse
 import openexp.exceptions
 import openexp._mouse.legacy
 from psychopy import event
+import psychopy.visual
 
 class psycho(openexp._mouse.legacy.legacy):
 
@@ -68,7 +69,17 @@ class psycho(openexp._mouse.legacy.legacy):
 		"""See openexp._mouse.legacy"""
 	
 		self.visible = visible
-		self.mouse.setVisible(visible)		
+		self.mouse.setVisible(visible)
+
+	def set_pos(self, pos=(0,0)):
+
+		"""See openexp._mouse.legacy"""	
+
+		if psychopy.visual.openWindows[0].winType == 'pyglet':
+			raise openexp.exceptions.response_error( \
+				"Method set_pos not supported in pyglet environment (default for psycho back-end)")
+
+		self.mouse.setPos(newPos=pos)
 		
 	def get_click(self, buttonlist=None, timeout=None, visible=None):
 	
@@ -117,6 +128,12 @@ class psycho(openexp._mouse.legacy.legacy):
 		x = x + self.experiment.width/2
 		y = self.experiment.height/2 - y
 		return (x, y), t
+
+	def get_pressed(self):
+	
+		"""See openexp._mouse.legacy"""
+
+		return tuple(self.mouse.getPressed(getTime=False))
 		
 	def flush(self):
 	


### PR DESCRIPTION
Now including the runtime error when set_pos is called in a pyglet environment

Slight point of comment: now only check first window in existence, which is fine for now, but could be reconsidered if support for multiple monitors is ever added. But, now that I think of it: why would one create one pygame psychopy window and one pyglet?
