### PR TITLE
Flush buffers *before* sending stop/start byte.

### DIFF
--- a/plugins/srbox/libsrbox.py
+++ b/plugins/srbox/libsrbox.py
@@ -120,14 +120,14 @@ class libsrbox:
 		</DOC>"""
 
 		# Write the start byte
-		self._srbox.write('\xA0')
 		self._srbox.flushOutput()
 		self._srbox.flushInput()
+		self._srbox.write('\xA0')
 
 	def stop(self):
 
 		"""<DOC>
-		Turns of sending mode, to stop giving output.
+		Turns off sending mode, to stop giving output.
 
 		Example:
 		>>> exp.srbox.start()
@@ -138,9 +138,9 @@ class libsrbox:
 		</DOC>"""
 
 		# Write the stop byte and flush the input
-		self._srbox.write('\x20')
 		self._srbox.flushOutput()
 		self._srbox.flushInput()
+		self._srbox.write('\x20')
 
 	def get_button_press(self, allowed_buttons=None, timeout=None):
 


### PR DESCRIPTION
In our lab we have found that button boxes sometimes stop responding during an experiment. It appears that the start byte is not always received, possibly because the buffers are flushed too quickly while the start byte is in the buffer. We find that flushing the buffers before sending the start/stop byte is more reliable. Is there any reason not to do so?
