### PR TITLE
Don't show Welcome tab when error occurred.

### DIFF
--- a/opensesame_extensions/opensesame_3_notifications/opensesame_3_notifications.py
+++ b/opensesame_extensions/opensesame_3_notifications/opensesame_3_notifications.py
@@ -58,7 +58,7 @@ class opensesame_3_notifications(base_extension):
 			Called at the end of the OpenSesame startup process.
 		"""
 
-		if cfg.os3n_new_user_notification:
+		if cfg.os3n_new_user_notification and not self.experiment.items.error_log:
 			self.tabwidget.open_markdown(self.ext_resource(u'new-user.md'),
 				title=u'Welcome!')
 


### PR DESCRIPTION
Don't show *Welcome* tab when error occurred. This will make sure the *Error* tab is not 'overwritten/covered' by the *Welcome* tab. I think this is especially important in *One-tab mode* because one might get very confused when missing the "No module named SomeMissingPlugin" message. When the SomeMissingPlugin plugin isn't on their system.

Try opening the attached experiment (after changing .txt to .osexp) by double clicking it. Using opensesame_3.1.9-py2.7-win32-1.exe with the Welcome message still enabled and in One-tab mode

[Example.txt](https://github.com/smathot/OpenSesame/files/1299981/Example.txt)

