### PR TITLE
Fix experiment.end() not closing log files

### DIFF
--- a/libopensesame/experiment.py
+++ b/libopensesame/experiment.py
@@ -473,7 +473,10 @@ class experiment(item.item):
 
 		from openexp import sampler, canvas
 		self.running = False
-		self._log.close()
+		try:
+			self._log.close()
+		except:
+			pass
 		sampler.close_sound(self)
 		canvas.close_display(self)
 		self.cleanup()

--- a/libopensesame/experiment.py
+++ b/libopensesame/experiment.py
@@ -473,12 +473,7 @@ class experiment(item.item):
 
 		from openexp import sampler, canvas
 		self.running = False
-		try:
-			self._log.flush()
-			os.fsync(self._log)
-			self._log.close()
-		except:
-			pass
+		self._log.close()
 		sampler.close_sound(self)
 		canvas.close_display(self)
 		self.cleanup()


### PR DESCRIPTION
`experiment.end()` never calls `self._log.close()`, because the other two lines in the try-block always throw an exception:
`self._log` references an instance of one of the log backends here, e.g. `csv`. The `csv` class does not have `flush()` defined and is not a file descriptor that could be used as an argument to `os.fsync()`. The file descriptor that is meant to be accessed in both cases is actually at `self._log._log` in this case. However `flush()` and `os.fsync()` don't need to be called at all, because the csv logger already calls those for each call to `csv.write()`.