### PR TITLE
add useRetina param for psychopy; fix UI disactivation

### DIFF
--- a/libqtopensesame/qtopensesame.py
+++ b/libqtopensesame/qtopensesame.py
@@ -1017,8 +1017,6 @@ class qtopensesame(QtWidgets.QMainWindow, base_component):
 				type:	bool
 		"""
 
-		if sys.platform == 'darwin':
-			return
 		self.block_close_event = not enabled
 		self.ui.dock_overview.setEnabled(enabled)
 		self.ui.centralwidget.setEnabled(enabled)

--- a/openexp/_canvas/psycho.py
+++ b/openexp/_canvas/psycho.py
@@ -124,7 +124,8 @@ class Psycho(Canvas, PsychoCoordinates):
 			units=u'pix',
 			color=Color(experiment, experiment.var.background).backend_color,
 			winType=u'pyglet',
-			allowStencil=True
+			allowStencil=True,
+			useRetina=false
 		)
 		event.Mouse(visible=False, win=experiment.window)
 		experiment.window.winHandle.set_caption(


### PR DESCRIPTION
Some fixes to make the upcoming OS 3.2 release work on the Mac.

- UI is now disabled when running an experiment, with the exception of the kill button (just like on the other platforms).
- the `useRetina` parameter has been added to the psychopy init_window function. This does not really do anything for the currently used version of psychopy (or rather pyglet), but will become important when these modules get updated in the future. I prefer to explicitly mention it already so it can easily be changed.