### PR TITLE
Fix canvas.set_bgcolor

### DIFF
--- a/openexp/_canvas/canvas.py
+++ b/openexp/_canvas/canvas.py
@@ -1373,7 +1373,7 @@ class Canvas(Backend):
 		desc:		deprecated
 		"""
 
-		self.bgcolor = self.color
+		self.bgcolor = color
 
 	def set_font(self, style=None, size=None, italic=None, bold=None,
 		underline=None):


### PR DESCRIPTION
Even though this method is deprecated it should still work as expected.

However maybe adding a hint on how to set the background color the right way might be useful as well?

`set_bgcolor` is currently called from PyGaze's _screen in https://github.com/esdalmaijer/PyGaze/blob/6c07b263c91a0bd8c9c64aedfc2d76c18efa2abf/pygaze/_screen/osscreen.py#L191 - might want to change to the new way of doing this there as well.