### PR TITLE
Fix canvas element group __add__

### DIFF
--- a/openexp/_canvas/_element/group.py
+++ b/openexp/_canvas/_element/group.py
@@ -54,7 +54,7 @@ class Group(Element):
 
 	def __add__(self, element):
 
-		return Group(self.canvas, self._elements + [element])
+		return Group(self._canvas, self._elements + [element])
 
 	@staticmethod
 	def _setter(key, self, val):


### PR DESCRIPTION
AttributeError: 'Group' object has no attribute 'canvas'
Element sets this._canvas in __init__