### PR TITLE
Add screenshot function to canvas

### DIFF
--- a/openexp/_canvas/canvas.py
+++ b/openexp/_canvas/canvas.py
@@ -476,7 +476,7 @@ class Canvas(Backend):
 
 		"""
 		desc:
-			Determines the full path to save a screenshot to, and creates the necessary subfolders if necessary
+			Determines the full path to save a screenshot to, and creates subfolders if they do not exist.
 
 		arguments:
 			path:
@@ -484,10 +484,11 @@ class Canvas(Backend):
 				type: str
 
 		returns:
-			desc: The full path where the screenshot is to be stored.
+			desc: The full path where the screenshot will be stored.
 			type: str
 		"""
 
+		path = safe_decode(path)
 		# Check if supplied filename has a valid image extension
 		if not os.path.splitext(path)[1] in [u'.jpg', u'.jpeg', u'.png', u'.bmp', u'.tga']:
 			raise osexception(u"The filename does not have a valid image extension. Use .jpg, .jpeg, \
@@ -502,7 +503,6 @@ class Canvas(Backend):
 		if not os.path.isdir(file_dir):
 			os.makedirs(file_dir)
 		return path
-
 
 	def elements_at(self, x, y):
 

--- a/openexp/_canvas/canvas.py
+++ b/openexp/_canvas/canvas.py
@@ -18,6 +18,7 @@ along with OpenSesame.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 from libopensesame.py3compat import *
+import os
 import warnings
 import random
 import math
@@ -471,6 +472,38 @@ class Canvas(Backend):
 				return name, element
 		raise ValueError('"%s" not found in canvas"' % element)
 
+	def _screenshot_path(self, path):
+
+		"""
+		desc:
+			Determines the full path to save a screenshot to, and creates the necessary subfolders if necessary
+
+		arguments:
+			path:
+				desc: The relative or absolute path to the screnshot.
+				type: str
+
+		returns:
+			desc: The full path where the screenshot is to be stored.
+			type: str
+		"""
+
+		# Check if supplied filename has a valid image extension
+		if not os.path.splitext(path)[1] in [u'.jpg', u'.jpeg', u'.png', u'.bmp', u'.tga']:
+			raise osexception(u"The filename does not have a valid image extension. Use .jpg, .jpeg, \
+				png, .bmp or .tga")
+
+		# Check if image file path is absolute, if not, find relative path to current experiment file
+		if not os.path.isabs(path):
+			path = os.path.abspath(os.path.join(self.experiment.experiment_path, path))
+
+		# Create any subfolders if necessary
+		file_dir = os.path.dirname(path)
+		if not os.path.isdir(file_dir):
+			os.makedirs(file_dir)
+		return path
+
+
 	def elements_at(self, x, y):
 
 		"""
@@ -799,6 +832,29 @@ class Canvas(Backend):
 		"""
 
 		raise NotImplementedError()
+
+	def screenshot(self, path):
+
+		"""
+		desc:
+			Saves a screenshot of the canvas to a file
+
+		arguments:
+			path:
+				desc: The location and filename to save the image to. If an absolute path is
+					provided, the file will be saved there. If a relative path is provided,
+					the file will be saved to that folder relative to the location of the
+					experiment file.
+				type: str
+
+		returns:
+			desc:
+				The absolute path to the file that has just been saved
+			type:
+				str
+		"""
+		raise NotImplementedError()
+
 
 	@configurable
 	def clear(self, **style_args):

--- a/openexp/_canvas/legacy.py
+++ b/openexp/_canvas/legacy.py
@@ -100,6 +100,12 @@ class Legacy(Canvas, LegacyCoordinates):
 			oslogger.warning('Canvas.show() took {0} ms'.format(t1 - t0))
 		return t1
 
+	def screenshot(self, path):
+
+		path = self._screenshot_path(path)
+		pygame.image.save(self.surface, path)
+		return path
+
 	def _show_macos(self):
 
 		"""

--- a/openexp/_canvas/psycho.py
+++ b/openexp/_canvas/psycho.py
@@ -107,6 +107,15 @@ class Psycho(Canvas, PsychoCoordinates):
 			oslogger.warning('Canvas.show() took {0} ms'.format(t1 - t0))
 		return t1
 
+	def screenshot(self, path):
+
+		path = self._screenshot_path(path)
+		for e in self._elements.values():
+			e.show()
+		self.experiment.window.getMovieFrame('back')
+		self.experiment.window.saveMovieFrames(path)
+		return path
+
 	def _set_background(self):
 
 		if u'__background__' in self:

--- a/openexp/_canvas/xpyriment.py
+++ b/openexp/_canvas/xpyriment.py
@@ -79,6 +79,12 @@ class Xpyriment(Canvas, XpyrimentCoordinates):
 			oslogger.warning('Canvas.show() took {0} ms'.format(t1 - t0))
 		return t1
 
+	def screenshot(self, path):
+
+		path = self._screenshot_path(path)
+		self.experiment.expyriment.screen.save(path)
+		return path
+
 	def _set_background(self):
 
 		self._background = stimuli.BlankScreen(

--- a/openexp/_canvas/xpyriment.py
+++ b/openexp/_canvas/xpyriment.py
@@ -82,6 +82,11 @@ class Xpyriment(Canvas, XpyrimentCoordinates):
 	def screenshot(self, path):
 
 		path = self._screenshot_path(path)
+		elements = [e for g in self._elements.values() if g.visible for e in g]
+		self._background.present(clear=True, update=False)
+		while elements:
+			e = elements.pop(0)
+			e.show(clear=False, update=False)
 		self.experiment.expyriment.screen.save(path)
 		return path
 


### PR DESCRIPTION
This is a long overdue implementation of https://github.com/smathot/OpenSesame/issues/318. I've followed your instructions in that issue as close as I could. I tested the functionality in a simple experiment and it seems to work with all backends. Yet, I still have some reservations, and I would like to hear your thoughts on the following points:

- The xpyriment and psycho backend only allow to take a screenshot of the currently active back buffer, so they need to redraw the canvas each time before a screenshot is created. This is done by mimicking the `show()` function, but ommitting the flip or update action of the display, so the back buffer is never drawn to the screen. This feels quite 'hacky', but I can't think of a better solution, even after endlessly searching for alternatives.
- Related to the previous point, I'm not sure if I need to clear, or otherwise clean, the back buffer after it has been drawn to by the screenshot function. My preliminary tests show no problems if you skip this step, but I reckon there are situations in which 'residual' elements.
- I think we should guard for permission errors and the like when trying to create subfolders with `os.makedirs()` (https://github.com/smathot/OpenSesame/commit/4cbc7cea8c57ff0766aa14d77133fc7f9a82370b#diff-f2dce170dbe3213bf48dee492214299eR503), but I don't know what's the best way to do this that fits OpenSesame. Should I catch IOErrors or OSErrors here and raise an osexception instead? How do I make sure the relevant traceback is shown then? Any advice on the best way to go at this? 
- I was planning on writing unit tests for this function, but then of course I realised we are working with graphical elements again here, which always makes it more difficult. Do you have any ideas on how to we could best approach this, or if unit testing the screenshot function is really necessary?