### PR TITLE
Enable scaling on HiDPI displays

### DIFF
--- a/libqtopensesame/__main__.py
+++ b/libqtopensesame/__main__.py
@@ -21,7 +21,7 @@ from libopensesame.py3compat import *
 import os
 import sys
 import platform
-
+os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
 
 def set_paths():
 
@@ -86,9 +86,12 @@ def opensesame():
 	except ImportError:
 		pass
 	app = QApplication(sys.argv)
-	# Enable High DPI display with PyQt5
+	# Enable High DPI pixmaps with PyQt5
 	if hasattr(qtpy.QtCore.Qt, 'AA_UseHighDpiPixmaps'):
 		app.setAttribute(qtpy.QtCore.Qt.AA_UseHighDpiPixmaps)
+	# Enable scaling for High DPI displays with PyQt5
+	if hasattr(qtpy.QtCore.Qt, 'AA_EnableHighDpiScaling'):
+		app.setAttribute(qtpy.QtCore.Qt.AA_EnableHighDpiScaling)
 	from libqtopensesame.qtopensesame import qtopensesame
 	opensesame = qtopensesame(app)
 	opensesame.__script__ = __file__


### PR DESCRIPTION
This simple fix should cause OpenSesame to play well with HiDPI displays. Especially in setups with multiple monitors that each have different DPI, OpenSesame can behave funky when being dragged from one screen to another, causing it to display everything too large or too small. The example below is when I dragged OpenSesame from a HiDPI (4k) to lower dpi (Full HD) screen; everything became quite large.

![OSScreenshot](https://user-images.githubusercontent.com/689044/57067497-7f394300-6ccf-11e9-8c0f-8f0008c60311.png)

Qt has built in functions to incorporate for this, thereby becoming 'dpi aware', but you need to explicitly activate this, and we never did so. 