### PR TITLE
Added ssl certificate finder for MacOS

### DIFF
--- a/libqtopensesame/__main__.py
+++ b/libqtopensesame/__main__.py
@@ -32,13 +32,24 @@ if sys.executable.endswith('pythonw.exe'):
 	sys.stderr = open(os.devnull, 'w')
 	sys.stdin = open(os.devnull)
 
+# On MacOS, the locations of the SSL cerfificates need to be explicitly indicated when packaged
+# as an app, otherwise urllib.urlopen fails with an SSL related error. To do so, we make use of the
+# certifi package that can provide this location, but it is unclear if certifi is always installed,
+# so let's fail gracefully if it isn't.
+if platform.system() == 'Darwin':
+	try:
+		import certifi
+		os.environ['SSL_CERT_FILE'] = certifi.where()
+		os.environ['SSL_CERT_DIR'] = os.path.dirname(certifi.where())
+	except ImportError:
+		pass # Or log something here?
 
 def patch_pyqt():
 
 	"""This patches PyQt such that properties are removed from objects before
 	connectSlotsByName() tries to inspect the object. This is necessary because
 	in some versions, the introspection crashes when properties cannot be
-	accessed, for example because the object to be initialized first.
+	accessed, for example because the object needs to be initialized first.
 	"""
 
 	def _(fnc):


### PR DESCRIPTION
When packaged as a MacOS app, the paths to ssl certificates, which are used by urlopen when connecting to *any* website (even not https ones), are somehow hardcoded into the ssl module and pointed to my local dir containing the ssl certificates in my conda environment . It may be worth to check this also under windows and fix this there too if necessary by removing the platform check part of this PR. You can check the ssl certificate paths by executing:

```python
import _ssl
_ssl.get_default_verify_paths()
```
this returns a dictionary with the default (hardcoded) locations.
I dove into the code of _ssl and saw that specifications of these locations in ENV have precedence over the hardcoded locations, so that's how I solved this problem, but elegance is another thing (I don't really like my local paths exposed in an app that goes everywhere 😅. 