### PR TITLE
avoid shader error for Linux with Nvidia drivers

### DIFF
--- a/libqtopensesame/__main__.py
+++ b/libqtopensesame/__main__.py
@@ -25,6 +25,11 @@ import platform
 # On Linux this appears to be buggy
 if platform.system() != 'Linux':
 	os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
+
+# solves a library conflict for Linux with Nvidia drivers
+if platform.system() == 'Linux':
+	from OpenGL import GL
+
 # Attach a dummy console when launched with pythonw.exe. This is necessary for
 # some libraries.
 if sys.executable.endswith('pythonw.exe'):


### PR DESCRIPTION
workaround for well known Qt problem when running under Linux with Nvidia drivers:
https://forum.qt.io/topic/81328/ubuntu-qopenglshaderprogram-shader-program-is-not-linked

tested under:
Ubuntu 16.04
OpenGL 4.6.0
NVIDIA 396.82
OpenSesame 3.3.4a9