### PR TITLE
Update psycho.py

### DIFF
--- a/openexp/_sampler/psycho.py
+++ b/openexp/_sampler/psycho.py
@@ -189,13 +189,18 @@ class Psycho(Sampler):
         self._sound.play()
 
     def is_playing(self):
-
-        return self._sound.status == PLAYING
+        if hasattr(self._sound, 'isPlaying'):
+            return self._sound.isPlaying
+        else:
+            return self._sound.status == PLAYING
 
     def wait(self):
-
-        while self._sound.status == PLAYING:
-            self._keyboard.flush()
+        if hasattr(self._sound, 'isPlaying'):
+            while self._sound.isPlaying:
+                self._keyboard.flush()
+        else:
+            while self._sound.status == PLAYING:
+                self._keyboard.flush()
 
     @staticmethod
     def init_sound(experiment):
@@ -207,7 +212,8 @@ class Psycho(Sampler):
             experiment.var.get('psycho_audiolib', 'sounddevice')
         ]
         from psychopy import constants
-        PLAYING = constants.PLAYING
+        if hasattr(constants, 'PLAYING'):
+            PLAYING = constants.PLAYING
         from psychopy.sound import Sound
 
     @staticmethod


### PR DESCRIPTION
PsychoPy made changes to their Sound object: https://github.com/psychopy/psychopy/commit/50a730b7be0bb1a219d5666d657bad4c8cc121d1. The `status` property has been removed, and replaced with an `isPlaying` property. The proposed change covers both cases depending on the version of PsychoPy that is being used.

Note that on Linux with Python 3.10, I had to upgrade to some more recent version of PsychoPy to get OpenSesame to work. But I noticed that the Sampler item was not properly waiting for the sound to be finished like it should... and I believe this is where it is coming from. I haven't tried to patch my version of OpenSesame to see if that solves the issue though.