### PR TITLE
fix missing import in image widget

### DIFF
--- a/libopensesame/widgets/_image.py
+++ b/libopensesame/widgets/_image.py
@@ -23,6 +23,7 @@ from PIL import Image
 from libopensesame.exceptions import ImageDoesNotExist, UnsupportedImageFormat
 from openexp.canvas_elements import Image as ImageElement
 import os
+import sys
 
 
 class ImageWidget(Widget):


### PR DESCRIPTION
Image widgets currently don't work because the line 
[        _path = safe_str(self.path, enc=sys.getfilesystemencoding())](https://github.com/open-cogsci/OpenSesame/blob/08f2754e1f455a8973df39e536d6ed58a1ff10e3/libopensesame/widgets/_image.py#L86)
requires `sys` to be imported, which it is not.  This commits fixes this.
