### PR TITLE
fix form consent not proceeding

### DIFF
--- a/opensesame_plugins/core/form_consent/form_consent.py
+++ b/opensesame_plugins/core/form_consent/form_consent.py
@@ -60,7 +60,7 @@ class FormConsent(FormBase):
             super().run()
             if self.var.get(u'checkbox_status') == \
                     self.var.get(u'checkbox_text') and \
-                    self.var.get(u'accept_status') == u'yes':
+                    self.var.get(u'accept_status') == 1:
                 break
             c = Canvas(self.experiment)
             c.text(self.var.get(u'decline_message'))


### PR DESCRIPTION
The consent form still expects the `accept_return` value to be `yes` or `no`, but as of 4.0 those values seem to be `1` and `0` respectively. This PR fixes that.