### PR TITLE
restrict mouse events that trigger click

### DIFF
--- a/libopensesame/widgets/_form.py
+++ b/libopensesame/widgets/_form.py
@@ -153,7 +153,7 @@ class Form:
             focus_widget.focus = True
         if len(self) == 0:
             raise InvalidFormGeometry('The form contains no widgets')
-        ms = mouse(self.experiment, timeout=0)
+        ms = mouse(self.experiment, button_list=[1, 2, 3], timeout=0)
         ms.show_cursor()
         kb = keyboard(self.experiment, timeout=0)
         kb.show_virtual_keyboard()

--- a/libopensesame/widgets/_form.py
+++ b/libopensesame/widgets/_form.py
@@ -153,7 +153,7 @@ class Form:
             focus_widget.focus = True
         if len(self) == 0:
             raise InvalidFormGeometry('The form contains no widgets')
-        ms = mouse(self.experiment, button_list=[1, 2, 3], timeout=0)
+        ms = mouse(self.experiment, buttonlist=[1, 2, 3], timeout=0)
         ms.show_cursor()
         kb = keyboard(self.experiment, timeout=0)
         kb.show_virtual_keyboard()


### PR DESCRIPTION
All mouse events (left/right/middle click, as well as turning the wheel and what not is currently triggering mouse events. 
This PR limits it to left/right/middle clicks by hard coding it. 

I couldn't see a benefit of making it a parameter. But maybe, we could restrict it even more? Like only left-clicks?