### PR TITLE
fix bug with g# in synth

### DIFF
--- a/openexp/synth.py
+++ b/openexp/synth.py
@@ -116,7 +116,7 @@ def key_to_freq(key):
     elif n == "g":
         f = 784.00
     elif n == "ab" or n == "g#":
-        f == 830.64
+        f = 830.64
     if o < 1:
         o = 0.5 ** (abs(o) + 1)
         freq = f * o


### PR DESCRIPTION
Bug fix for problems described in the [forum](https://forum.cogsci.nl/discussion/9045/synth-cannot-play-g-g-sharp)

There was a double `==` where there should only be one 