### PR TITLE
Update backend.py

### DIFF
--- a/openexp/backend.py
+++ b/openexp/backend.py
@@ -161,7 +161,7 @@ def configurable(fnc):
     # We need to copy the docstring and argument specification, otherwise using
     # this decorator will break the documentation functions.
     inner.__doc__ = fnc.__doc__
-    inner.__argspec__ = inspect.getargspec(fnc)
+    inner.__argspec__ = inspect.getfullargspec(fnc)
     inner.__name__ = fnc.__name__
     if FunctionDoc is not None:
         inner._dict = FunctionDoc(fnc)._dict()


### PR DESCRIPTION
getargspec() is not available anymore on my python3.11 version so I get an "AttributeError: module 'inspect' has no attribute 'getargspec'."

inspect.getfullargspec(func) seems to be the replacement.